### PR TITLE
Add a dehyphenate method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Or install it yourself as:
     => "978-4-8156-0644-2"
     irb(main):006:0> Petrarca.hyphenate("9784815606442")
     => "978-4-8156-0644-2"
+    irb(main):007:0> Petrarca.dehyphenate("978-4-8156-0644-2")
+    => "9784815605442"
 
 Accept Integer as ISBN, only if no `-` and `X` including.
 

--- a/lib/petrarca.rb
+++ b/lib/petrarca.rb
@@ -15,7 +15,7 @@ module Petrarca
   extend self
 
   def valid?(isbn)
-    case isbn.to_s.delete("-").size
+    case dehyphenate(isbn).size
     when 13
       ISBN13.valid?(isbn)
     when 10
@@ -26,7 +26,7 @@ module Petrarca
   end
 
   def correct_format?(isbn)
-    case isbn.to_s.delete("-").size
+    case dehyphenate(isbn).size
     when 13
       ISBN13.correct_format?(isbn)
     when 10
@@ -37,7 +37,7 @@ module Petrarca
   end
 
   def calc_check_digit(isbn)
-    isbn = isbn.to_s.delete("-")
+    isbn = dehyphenate(isbn)
     case isbn.size
     when 12, 13
       ISBN13.calc_check_digit(isbn)
@@ -46,6 +46,10 @@ module Petrarca
     else
       raise IncorrectFormatError
     end
+  end
+
+  def dehyphenate(isbn)
+    isbn.to_s.delete("-")
   end
 
   def hyphenate(isbn)
@@ -59,12 +63,12 @@ module Petrarca
   end
 
   def to_10(isbn13)
-    s = isbn13.to_s.delete("-")[3, 9]
+    s = dehyphenate(isbn13)[3, 9]
     ISBN10.hyphenate(s + ISBN10.calc_check_digit(s))
   end
 
   def to_13(isbn10)
-    s = "978" + isbn10.to_s.delete("-")[0, 9]
+    s = "978" + dehyphenate(isbn10)[0, 9]
     ISBN13.hyphenate(s + ISBN13.calc_check_digit(s))
   end
 

--- a/lib/petrarca/helpers.rb
+++ b/lib/petrarca/helpers.rb
@@ -8,7 +8,7 @@ module Petrarca
     extend self
 
     def split(isbn)
-      isbn = isbn.to_s.delete("-")
+      isbn = Petrarca.dehyphenate(isbn)
       ean_prefix = isbn[0, 3]
       unless ean_prefix == "978" || ean_prefix == "979"
         raise InvalidEANPrefixError.new("Invalid EAN prefix: #{ean_prefix}")

--- a/lib/petrarca/isbn10.rb
+++ b/lib/petrarca/isbn10.rb
@@ -20,12 +20,12 @@ module Petrarca
     end
 
     def correct_format?(isbn)
-      isbn = isbn.to_s.delete("-")
+      isbn = dehyphenate(isbn)
       !!(/\A\d{9}[0-9X]\z/ =~ isbn)
     end
 
     def calc_check_digit(isbn)
-      nums = isbn.to_s.delete("-").split("")[0, 9].map{|x| x.to_i }
+      nums = dehyphenate(isbn).split("")[0, 9].map{|x| x.to_i }
       sum = nums.zip((2..10).to_a.reverse).map{|x, y| x * y }.inject(:+)
       check_digit = 11 - (sum % 11)
       case check_digit
@@ -36,6 +36,10 @@ module Petrarca
       else
         check_digit.to_s
       end
+    end
+    
+    def dehyphenate(isbn)
+      Petrarca.dehyphenate(isbn)
     end
 
     def hyphenate(isbn)

--- a/lib/petrarca/isbn13.rb
+++ b/lib/petrarca/isbn13.rb
@@ -20,15 +20,19 @@ module Petrarca
     end
 
     def correct_format?(isbn)
-      isbn = isbn.to_s.delete("-")
+      isbn = dehyphenate(isbn)
       !!(/\A97[89]\d{9}\d\z/ =~ isbn)
     end
 
     def calc_check_digit(isbn)
-      nums = isbn.to_s.delete("-").split("")[0, 12].map{|x| x.to_i }
+      nums = dehyphenate(isbn).split("")[0, 12].map{|x| x.to_i }
       sum = nums.zip([1, 3] * 6).map{|x, y| x * y }.inject(:+)
       check_digit = 10 - (sum % 10)
       check_digit == 10 ? "0" : check_digit.to_s
+    end
+
+    def dehyphenate(isbn)
+      Petrarca.dehyphenate(isbn)
     end
 
     def hyphenate(isbn)

--- a/spec/isbn10_spec.rb
+++ b/spec/isbn10_spec.rb
@@ -4,7 +4,9 @@ require_relative "../lib/petrarca"
 RSpec.describe Petrarca::ISBN10 do
 
   let(:valid_isbn10) { "4-8156-0644-7" }
+  let(:valid_isbn10_dehyphenated) { "4815606447" }
   let(:invalid_isbn10) { "4-8156-0644-0" }
+  let(:invalid_isbn10_dehyphenated) { "4815606440" }
   let(:correct_check_digit) { "7" }
 
   describe "valid?" do
@@ -33,11 +35,21 @@ RSpec.describe Petrarca::ISBN10 do
 
   describe "hyphenate" do
     it "returns hyphenated for valid isbn10" do
-      expect(Petrarca::ISBN10.hyphenate(valid_isbn10.delete("-"))).to eq valid_isbn10
+      expect(Petrarca::ISBN10.hyphenate(valid_isbn10_dehyphenated)).to eq valid_isbn10
     end
 
     it "returns hyphenated for also invalid isbn10" do
-      expect(Petrarca::ISBN10.hyphenate(invalid_isbn10.delete("-"))).to eq invalid_isbn10
+      expect(Petrarca::ISBN10.hyphenate(invalid_isbn10_dehyphenated)).to eq invalid_isbn10
+    end
+  end
+
+  describe "dehyphenate" do
+    it "returns dehyphenated for valid isbn10" do
+      expect(Petrarca::ISBN10.dehyphenate(valid_isbn10)).to eq valid_isbn10_dehyphenated
+    end
+
+    it "returns hyphenated for also invalid isbn10" do
+      expect(Petrarca::ISBN10.dehyphenate(invalid_isbn10)).to eq invalid_isbn10_dehyphenated
     end
   end
 

--- a/spec/isbn13_spec.rb
+++ b/spec/isbn13_spec.rb
@@ -4,7 +4,9 @@ require_relative "../lib/petrarca"
 RSpec.describe Petrarca::ISBN13 do
 
   let(:valid_isbn13) { "978-4-8156-0644-2" }
+  let(:valid_isbn13_dehyphenated) { "9784815606442" }
   let(:invalid_isbn13) { "978-4-8156-0644-0" }
+  let(:invalid_isbn13_dehyphenated) { "9784815606440" }
   let(:correct_check_digit) { "2" }
 
   describe "valid?" do
@@ -33,12 +35,22 @@ RSpec.describe Petrarca::ISBN13 do
 
   describe "hyphenate" do
     it "returns hyphenated for valid isbn13" do
-      expect(Petrarca::ISBN13.hyphenate(valid_isbn13.delete("-"))).to eq valid_isbn13
+      expect(Petrarca::ISBN13.hyphenate(valid_isbn13_dehyphenated)).to eq valid_isbn13
     end
 
     it "returns hyphenated for also invalid isbn13" do
-      expect(Petrarca::ISBN13.hyphenate(invalid_isbn13.delete("-"))).to eq invalid_isbn13
+      expect(Petrarca::ISBN13.hyphenate(invalid_isbn13_dehyphenated)).to eq invalid_isbn13
     end
   end
 
+  describe "dehyphenate" do
+    it "returns dehyphenated for valid isbn13" do
+      expect(Petrarca::ISBN10.dehyphenate(valid_isbn13)).to eq valid_isbn13_dehyphenated
+    end
+
+    it "returns dehyphenated for also invalid isbn13" do
+      expect(Petrarca::ISBN10.dehyphenate(invalid_isbn13)).to eq invalid_isbn13_dehyphenated
+    end
+  end
+    
 end

--- a/spec/petrarca_spec.rb
+++ b/spec/petrarca_spec.rb
@@ -4,12 +4,19 @@ require_relative "../lib/petrarca"
 RSpec.describe Petrarca do
 
   let(:valid_isbn13) { "978-4-8156-0644-2" }
+  let(:valid_isbn13_dehyphenated) { "9784815606442"}
   let(:invalid_isbn13) { "978-4-8156-0644-0" }
+  let(:invalid_isbn13_dehyphenated) { "9784815606440" }
   let(:correct_check_digit_isbn13) { "2" }
+
   let(:valid_isbn10) { "4-8156-0644-7" }
+  let(:valid_isbn10_dehyphenated) { "4815606447"}
   let(:invalid_isbn10) { "4-8156-0644-0" }
+  let(:invalid_isbn10_dehyphenated) { "4815606440" }
   let(:correct_check_digit_isbn10) { "7" }
+
   let(:nonsence_isbn) { "1-234-567-8" }
+
 
   describe "valid?" do
     context "isbn13" do
@@ -72,21 +79,43 @@ RSpec.describe Petrarca do
   describe "hyphenate" do
     context "isbn13" do
       it "returns hyphenated for valid isbn13" do
-        expect(Petrarca.hyphenate(valid_isbn13.delete("-"))).to eq valid_isbn13
+        expect(Petrarca.hyphenate(valid_isbn13_dehyphenated)).to eq valid_isbn13
       end
 
       it "returns hyphenated for also invalid isbn13" do
-        expect(Petrarca.hyphenate(invalid_isbn13.delete("-"))).to eq invalid_isbn13
+        expect(Petrarca.hyphenate(invalid_isbn13_dehyphenated)).to eq invalid_isbn13
       end
     end
 
     context "isbn10" do
       it "returns hyphenated for valid isbn10" do
-        expect(Petrarca.hyphenate(valid_isbn10.delete("-"))).to eq valid_isbn10
+        expect(Petrarca.hyphenate(valid_isbn10_dehyphenated)).to eq valid_isbn10
       end
 
       it "returns hyphenated for also invalid isbn10" do
-        expect(Petrarca.hyphenate(invalid_isbn10.delete("-"))).to eq invalid_isbn10
+        expect(Petrarca.hyphenate(invalid_isbn10_dehyphenated)).to eq invalid_isbn10
+      end
+    end
+  end
+
+  describe "dehyphenate" do
+    context "isbn13" do
+      it "returns dehyphenated for valid isbn13" do
+        expect(Petrarca.dehyphenate(valid_isbn13)).to eq valid_isbn13_dehyphenated
+      end
+
+      it "returns dehyphenated for also invalid isbn13" do
+        expect(Petrarca.dehyphenate(invalid_isbn13)).to eq invalid_isbn13_dehyphenated
+      end
+    end
+
+    context "isbn10" do
+      it "returns dehyphenated for valid isbn10" do
+        expect(Petrarca.dehyphenate(valid_isbn10)).to eq valid_isbn10_dehyphenated
+      end
+
+      it "returns dehyphenated for also invalid isbn10" do
+        expect(Petrarca.dehyphenate(invalid_isbn10)).to eq invalid_isbn10_dehyphenated
       end
     end
   end


### PR DESCRIPTION
 Hi!

Thank you for making Petrarca.

This PR add a `dehyphenate` method to the `Petrarca` module and to the `ISBN10` and `ISBN13` modules. This method replaces the often repeated `.to_s.delete("-")`

Some users of the gem may find this method convenient, so I have documented it in the README.

I have added rspec tests for `dehyphenate`, and refactored the `hyphenate` tests to use the new variables that the dehyphenate test depends on.

